### PR TITLE
Fix hang when max_execution_time is zero

### DIFF
--- a/src/RedisSessionHandler.php
+++ b/src/RedisSessionHandler.php
@@ -199,8 +199,13 @@ class RedisSessionHandler extends \SessionHandler
     private function acquireLockOn($session_id)
     {
         $wait = self::MIN_WAIT_TIME;
+        if ($this->lock_ttl) {
+            $options = ['nx', 'ex' => $this->lock_ttl];
+        } else {
+            $options = ['nx'];
+        }
 
-        while (false === $this->redis->set("{$session_id}_lock", '', ['nx', 'ex' => $this->lock_ttl])) {
+        while (false === $this->redis->set("{$session_id}_lock", '', $options)) {
             usleep($wait);
 
             if (self::MAX_WAIT_TIME > $wait) {

--- a/tests/e2e/BasicTest.php
+++ b/tests/e2e/BasicTest.php
@@ -138,6 +138,20 @@ class BasicTest extends EndToEndTestCase
     }
 
     /**
+     * This test checks that the server behaves correctly when a script is run that has no time limit
+     */
+    public function testUnlimitedExecutionTime()
+    {
+        $response = $this->http->send(
+            new Request('GET', '/visit-counter.php?with_no_time_limit')
+        );
+
+        $this->assertSame('1', (string) $response->getBody());
+        $this->assertCreatedNewSession($response);
+        $this->assertSame(1, $this->redis->dbSize());
+    }
+
+    /**
      * Asserts whether a received request triggered the creation of a new session.
      * It does so by searching for and inspecting the 'Set-Cookie' header.
      *

--- a/tests/webroot/visit-counter.php
+++ b/tests/webroot/visit-counter.php
@@ -6,6 +6,10 @@
 
 require_once __DIR__.'/../../vendor/autoload.php';
 
+if (isset($_GET['with_no_time_limit'])) {
+    set_time_limit(0);
+}
+
 session_set_save_handler(new \UMA\RedisSessionHandler(), true);
 
 session_start();


### PR DESCRIPTION
Hi Marcel,

I know the phpredis team have nearly added locking into the module but I am still using your code as a workaround at the moment. I noticed an issue whereby a script will hang if the execution time is not limited.

Please see attached pull request. I wasn't able to run the tests in Docker (it's nearby impossible to get PECL working in the php-cli image) so please check everything is working.

Kind Regards

Scott