### PR TITLE
Use cookie parameters as set in the session

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "env-rm": "docker-compose -f tests/docker-compose.yml down -v",
         "test": [
             "@env-up",
-            "docker exec -t tests_testrunner_1 sh -c 'php vendor/bin/phpunit'"
+            "docker exec -t tests_testrunner_1 sh -c 'vendor/bin/phpunit'"
         ]
     }
 }

--- a/src/RedisSessionHandler.php
+++ b/src/RedisSessionHandler.php
@@ -138,8 +138,8 @@ class RedisSessionHandler extends \SessionHandler
     {
         if ($this->mustRegenerate($session_id)) {
             session_id($session_id = $this->create_sid());
-
-            setcookie($this->cookieName, $session_id);
+            $params = session_get_cookie_params();
+            setcookie($this->cookieName, $session_id, time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
         }
 
         $this->acquireLockOn($session_id);

--- a/tests/webroot/visit-counter.php
+++ b/tests/webroot/visit-counter.php
@@ -8,6 +8,8 @@ require_once __DIR__.'/../../vendor/autoload.php';
 
 if (isset($_GET['with_no_time_limit'])) {
     set_time_limit(0);
+} elseif (isset($_GET['with_custom_cookie_params'])) {
+    session_set_cookie_params(86400, '/', '', true, true);
 }
 
 session_set_save_handler(new \UMA\RedisSessionHandler(), true);


### PR DESCRIPTION
Hi Marcel,

I've got another fix, this one is for regeneration cookies with non-default parameters such as long expiry, path, secure or HTTP only flags. Without this patch I end up with two distinct cookies in my browser when I use a non-existent session ID and browsers only replace cookies with matching parameters.

Thanks

Scott