### PR TITLE
Cookie lifetime fix on session regeneration

### DIFF
--- a/src/RedisSessionHandler.php
+++ b/src/RedisSessionHandler.php
@@ -139,7 +139,7 @@ class RedisSessionHandler extends \SessionHandler
         if ($this->mustRegenerate($session_id)) {
             session_id($session_id = $this->create_sid());
             $params = session_get_cookie_params();
-            setcookie($this->cookieName, $session_id, time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+            setcookie($this->cookieName, $session_id, $params['lifetime'] ? time() + $params['lifetime'] : 0, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
         }
 
         $this->acquireLockOn($session_id);


### PR DESCRIPTION
If session cookie is meant to live "until the browser is closed", it shouldn't expire instantly (time() + 0 == time()).