### PR TITLE
Correct type return from read() method in SessionHandlerInterface implementation

### DIFF
--- a/src/RedisSessionHandler.php
+++ b/src/RedisSessionHandler.php
@@ -159,7 +159,7 @@ class RedisSessionHandler extends \SessionHandler
             return '';
         }
 
-        return $this->redis->get($session_id);
+        return (string)$this->redis->get($session_id);
     }
 
     /**


### PR DESCRIPTION
As it said at https://www.php.net/manual/en/class.sessionhandlerinterface.php , any custom session handler must return a string from the read() method.

This ensures the returning value is a string, not a random boolean.