### PR TITLE
support local Unix paths as well as ip:port as means to connect to Redis

### DIFF
--- a/src/RedisSessionHandler.php
+++ b/src/RedisSessionHandler.php
@@ -105,8 +105,17 @@ class RedisSessionHandler extends \SessionHandler
             $host, $port, $timeout, $prefix, $auth, $database
         ) = SavePathParser::parse($save_path);
 
-        if (false === $this->redis->connect($host, $port, $timeout)) {
-            return false;
+        // When $host is a Unix socket path redis->connect() will fail if
+        // supplied with any other of the optional parameters, even if they
+        // are the default values.
+        if (file_exists($host)) {
+            if (false === $this->redis->connect($host)) {
+                return false;
+            }
+        } else {
+            if (false === $this->redis->connect($host, $port, $timeout)) {
+                return false;
+            }
         }
 
         if (SavePathParser::DEFAULT_AUTH !== $auth) {

--- a/src/SavePathParser.php
+++ b/src/SavePathParser.php
@@ -49,6 +49,15 @@ class SavePathParser
      */
     public static function parse($path)
     {
+        // parse_url() is intended to parse URLs (but not URIs) so it cannot parse Unix
+        // socket paths. However for backwards compatibility reasons it can still parse
+        // URIs that start with 'file://'
+        //
+        // @see https://www.php.net/manual/en/function.parse-url.php
+        if (0 === strpos($path, 'unix://')) {
+            $path = str_replace('unix://', 'file://', $path);
+        }
+
         $parsed_path = parse_url($path);
 
         $host = isset($parsed_path['host']) ?

--- a/tests/unit/SavePathParserTest.php
+++ b/tests/unit/SavePathParserTest.php
@@ -29,6 +29,14 @@ class SavePathParserTest extends TestCase
                 '1.2.3.4',
                 ['1.2.3.4', SavePathParser::DEFAULT_PORT, SavePathParser::DEFAULT_TIMEOUT, SavePathParser::DEFAULT_PREFIX, SavePathParser::DEFAULT_AUTH, SavePathParser::DEFAULT_DATABASE]
             ],
+            'Unix path URI' => [
+                'unix:///var/run/redis/redis.sock?database=3',
+                ['/var/run/redis/redis.sock', SavePathParser::DEFAULT_PORT, SavePathParser::DEFAULT_TIMEOUT, SavePathParser::DEFAULT_PREFIX, SavePathParser::DEFAULT_AUTH, 3]
+            ],
+            'Unix path URI without prefix' => [
+                '/var/run/redis/redis.sock?database=3',
+                ['/var/run/redis/redis.sock', SavePathParser::DEFAULT_PORT, SavePathParser::DEFAULT_TIMEOUT, SavePathParser::DEFAULT_PREFIX, SavePathParser::DEFAULT_AUTH, 3]
+            ],
             'with port' => [
                 'localhost:1234',
                 ['localhost', 1234, SavePathParser::DEFAULT_TIMEOUT, SavePathParser::DEFAULT_PREFIX, SavePathParser::DEFAULT_AUTH, SavePathParser::DEFAULT_DATABASE]


### PR DESCRIPTION
Fix for issue #13 